### PR TITLE
fix wget command. fixes #3

### DIFF
--- a/setup-min.sh
+++ b/setup-min.sh
@@ -183,7 +183,7 @@ if [ -z "$NODEJS_VER" ]; then
     NODEJS_VER="$(curl -fsSL "$NODEJS_BASE_URL/dist/index.tab" | head -2 | tail -1 | cut -f 1)" \
       || echo 'error automatically determining current io.js version'
   elif [ -n "$(which wget)" ]; then
-    NODEJS_VER="wget --quiet "$NODEJS_BASE_URL/dist/index.tab" -O - | head -2 | tail -1 | cut -f 1)" \
+    NODEJS_VER="$(wget --quiet "$NODEJS_BASE_URL/dist/index.tab" -O - | head -2 | tail -1 | cut -f 1)" \
       || echo 'error automatically determining current io.js version'
   else
     echo "Found neither 'curl' nor 'wget'. Can't Continue."


### PR DESCRIPTION
The install script fails if curl is not installed because it sets the NODEJS_VER variable to ´wget --quiet https://nodejs.org/dist/index.tab -O - | head -2 | tail -1 | cut -f 1)´ instead of its returned value.
